### PR TITLE
Change node version in GH action yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ executors:
     shell: "/bin/bash -eo pipefail"
   node-executor:
     docker:
-      - image: node:16.13
+      - image: node:18.13
 
 commands:
   run-tests:


### PR DESCRIPTION
Pretty sure CI fails because semver wants 18 or higher (but was 16 still).